### PR TITLE
Replace st.echo with st.code

### DIFF
--- a/chapter1/chapter1.py
+++ b/chapter1/chapter1.py
@@ -2,11 +2,12 @@ import streamlit as st
 import torch
 import torch.nn as nn
 from transformers import AutoTokenizer
+import inspect
 
 torch.classes.__path__ = []
 
-with st.echo():
 
+def demo():
     model_name = "Qwen/Qwen3-0.6B"
     tokenizer = AutoTokenizer.from_pretrained(model_name)
 
@@ -14,9 +15,13 @@ with st.echo():
     # The second term is for the special tokens like <|endoftext|>.
     vocab_size = tokenizer.vocab_size + len(tokenizer.added_tokens_decoder)
 
+    st.text(f"{vocab_size = :,}")
 
-st.text(f"{vocab_size = :,}")
+    input_text = st.text_input("input_text", "Hello, world!")
 
-input_text = st.text_input("input_text", "Hello, world!")
+    st.write(input_text)
 
-st.write(input_text)
+
+st.code(inspect.getsource(demo), language="python")
+
+demo()


### PR DESCRIPTION
## Summary
- switch from `st.echo` to `st.code` for displaying the code block
- execute the displayed code so variables such as `vocab_size` are still defined

## Testing
- `python -m py_compile chapter1/chapter1.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843d39d12e08329947220e52ed04b88